### PR TITLE
Bugfix: CDS Submodule SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "C-Data-Structures"]
 	path = C-Data-Structures
-	url = git@github.com:Ludusamo/C-Data-Structures.git
+	url = https://github.com/Ludusamo/C-Data-Structures.git


### PR DESCRIPTION
### Changes
- Change CDS submodule from ssh to https.

### Reasons
- Now, non-contributors can clone the repository CDS.

Fixes #1 