### PR TITLE
Bugfix/conflicting getline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-`# Prerequisites
+# Prerequisites
 *.d
 
 # Object files

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Prerequisites
+`# Prerequisites
 *.d
 
 # Object files
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+bin/
+obj/

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,7 @@
 #include "compiler.h"
 #include "ang_primitives.h"
 
-char *getline(void) {
+char *get_line(void) {
     char * line = malloc(100), * linep = line;
     size_t lenmax = 100, len = lenmax;
     int c;
@@ -101,7 +101,7 @@ void run_repl() {
     char *expr;
     for (;;) {
         printf("> ");
-        expr = getline();
+        expr = get_line();
         run(expr);
         free(expr);
     }


### PR DESCRIPTION
### Changes
- Changed name of "getline" function to "get_line".

### Reasons
- To avoid naming conflicts on MacOS.

Fixes #2 