### PR TITLE
Fix: Linking error for CDS on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ remove:
 	@cd C-Data-Structures && $(MAKE) remove
 	make clean
 	$(RM) $(BINDIR)/$(TARGET)
+	$(RM) $(BINDIR)/libcds.so
 	echo "Executable removed!"
 
 memcheck:

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ $(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	$(CC) -c $(CFLAGS) $< -o $@
 	echo "Compiled "$<" successfully!"
 
+osx:
+	make
+	cp C-Data-Structures/bin/libcds.so ./bin/libcds.so
+
 clean:
 	@cd C-Data-Structures && $(MAKE) clean
 	$(RM) $(OBJECTS)


### PR DESCRIPTION
### Changes
- Create new target in Makefile so that Angstrom compiles on MacOS.

### Reasons
- So that Angstrom compiles on MacOS.

Fixes #5 